### PR TITLE
feat(email): add negative feedback email notification

### DIFF
--- a/apps/webapp/src/app/api/v2/prompts/[id]/quick-feedback/patch.ts
+++ b/apps/webapp/src/app/api/v2/prompts/[id]/quick-feedback/patch.ts
@@ -17,7 +17,7 @@ export const PATCH = createHandler()
   .use(parseBody(bodySchema))
   .use(pathParams<{ id: string }>())
   .handle(async (req, ctx) => {
-    const feedback = await QuickFeedbackService.upsertQuickFeedback(
+    await QuickFeedbackService.upsertQuickFeedback(
       {
         promptId: ctx.id,
         userId: ctx.userId,
@@ -27,8 +27,11 @@ export const PATCH = createHandler()
     );
 
     if (ctx.body.opinion === QuickFeedbackOpinions.negative) {
-      await sendNegativePromptFeedbackEmail(ctx.id);
+      sendNegativePromptFeedbackEmail(ctx.id).catch((error) => {
+        console.error("Failed to send negative feedback email:", error);
+      });
     }
+
     return NextResponse.json({
       message: "Quick feedback updated",
       success: true,
@@ -39,4 +42,5 @@ export type ResponseType = {
   message?: string;
   success: boolean;
 };
+
 export type RequestBodyType = z.infer<typeof bodySchema>;

--- a/apps/webapp/src/lib/email/sendNegativeReviewEmail.ts
+++ b/apps/webapp/src/lib/email/sendNegativeReviewEmail.ts
@@ -4,36 +4,57 @@ import { authUsers } from "drizzle-orm/supabase";
 import { eq } from "drizzle-orm";
 
 export async function sendNegativePromptFeedbackEmail(promptId: string) {
-  const [prompt] = await db
-    .select({
-      uploaderId: promptsTable.uploaderId,
-      question: promptsTable.question,
-    })
-    .from(promptsTable)
-    .where(eq(promptsTable.id, promptId));
+  const apiKey = process.env.FORWARD_EMAIL_API_KEY;
+  const senderEmail = process.env.SENDER_EMAIL;   
 
-  if (!prompt?.uploaderId) return;
+  if (!apiKey || !senderEmail) {
+    console.error("Missing email env vars");
+    return;
+  }
 
-  const [owner] = await db
-    .select({ email: authUsers.email })
-    .from(authUsers)
-    .where(eq(authUsers.id, prompt.uploaderId));
+  try {
+    const [prompt] = await db
+      .select({
+        uploaderId: promptsTable.uploaderId,
+        question: promptsTable.question,
+      })
+      .from(promptsTable)
+      .where(eq(promptsTable.id, promptId))
+      .limit(1); 
 
-  if (!owner?.email) return;
+    if (!prompt?.uploaderId) return;
 
-    await fetch("https://api.forwardemail.net/v1/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.FORWARD_EMAIL_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      from: `${process.env.SENDER_EMAIL}`,
-      to: owner.email,
-      subject: "Your prompt received a negative review",
-      text: `Your prompt "${prompt.question || "your prompt"}" received a negative review.
-            Someone left negative quick feedback on your prompt.  
-            Go check it out in your dashboard.`,
-    }),
-  });
+    const [owner] = await db
+      .select({ email: authUsers.email })
+      .from(authUsers)
+      .where(eq(authUsers.id, prompt.uploaderId))
+      .limit(1); 
+
+    if (!owner?.email) return;
+
+    const res = await fetch("https://api.forwardemail.net/v1/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`, 
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: senderEmail, 
+        to: owner.email,
+        subject: "Your prompt received a negative review",
+        text: `Your prompt "${prompt.question || "your prompt"}" received a negative review.
+                Someone left negative quick feedback on your prompt.
+                Go check it out in your dashboard.`, 
+      }),
+    });
+
+    if (!res.ok) {
+      console.error(
+        `Email API error ${res.status}:`,
+        await res.text()
+      );
+    }
+  } catch (err) {
+    console.error("Error preparing or sending email:", err);
+  }
 }


### PR DESCRIPTION
## ✉️ Email Notification for Negative Quick Feedback

### Summary
Adds automatic email notifications when a user receives **negative quick feedback** on their prompt.

### Changes
- Added email trigger in the quick-feedback PATCH route.
- Implemented `sendNegativePromptFeedbackEmail()` to fetch the prompt owner and send an email.
- Email dispatch is non-blocking and does not slow down the feedback request.
- Introduced required environment variables:
  - `FORWARD_EMAIL_API_KEY`
  - `SENDER_EMAIL`

## Walkthrough
A walkthrough video has been attached below for better understanding of the changes.
https://drive.google.com/file/d/16FSCWRSsuppAouMj6a3xnCnBHf_2V-V0/view?usp=sharing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt creators now receive automatic email alerts when their prompt gets negative quick feedback. Alerts include the prompt reference, a brief note about the negative review, and a direct link to the creator's dashboard for reviewing feedback and community insights.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->