### PR TITLE
fix: load data on compare/share page (closes #41)

### DIFF
--- a/apps/webapp/src/app/compare/share/[id]/page.tsx
+++ b/apps/webapp/src/app/compare/share/[id]/page.tsx
@@ -194,7 +194,9 @@ export default function SharedComparePage() {
                     )}
                   </span>
                   <Badge variant="secondary" className="text-xs font-normal">
-                    {matchData.modelA.name || matchData.modelA.modelId}
+                    {matchData.modelA.name && matchData.modelA.name !== "unknown"
+                      ? matchData.modelA.name
+                      : matchData.modelA.modelId}
                     {matchData.modelA.elo &&
                       ` (ELO: ${Math.round(matchData.modelA.elo)})`}
                   </Badge>
@@ -214,7 +216,7 @@ export default function SharedComparePage() {
                 >
                   {matchData.responseA ? (
                     <MarkdownText className="text-sm">
-                      {matchData.responseA.response}
+                      {matchData.responseA.data}
                     </MarkdownText>
                   ) : (
                     <div className="text-sm text-gray-500 italic">
@@ -241,7 +243,9 @@ export default function SharedComparePage() {
                   </span>
                   {matchData.modelB && (
                     <Badge variant="secondary" className="text-xs font-normal">
-                      {matchData.modelB.name || matchData.modelB.modelId}
+                      {matchData.modelB.name && matchData.modelB.name !== "unknown"
+                        ? matchData.modelB.name
+                        : matchData.modelB.modelId}
                       {matchData.modelB.elo &&
                         ` (ELO: ${Math.round(matchData.modelB.elo)})`}
                     </Badge>
@@ -262,7 +266,7 @@ export default function SharedComparePage() {
                 >
                   {matchData.responseB ? (
                     <MarkdownText className="text-sm">
-                      {matchData.responseB.response}
+                      {matchData.responseB.data}
                     </MarkdownText>
                   ) : (
                     <div className="text-sm text-gray-500 italic">


### PR DESCRIPTION
Fixes #41

## Summary

The compare/share page was not showing the models and responses for shared comparison links, even though the backend API returned the data. This PR wires the existing API response into the UI so that the shared page correctly displays the prompt, models, and responses.

## Changes

- Use `responseA.data` and `responseB.data` from the API to render the two model responses on the compare/share page.
- Use `modelA.name` / `modelB.name` when available; if the name is `"unknown"`, fall back to displaying `modelId` so the user can still identify the models.
- Ensure the share view uses the same fields as the main compare view so behavior is consistent.

## Testing

- Opened an existing compare/share link (e.g. the one mentioned in #41).
- Verified that:
  - Both model responses are now visible on the shared page.
  - Model labels are populated (using `name` or `modelId`).
  - The page loads without errors in the browser console.

## Screenshot
<img width="1460" height="880" alt="image" src="https://github.com/user-attachments/assets/532cfa0c-fded-4e03-879a-1a602eac1c7f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model name display in comparison badges to show model names when available, with model IDs as fallback
  * Fixed response data display in model comparison panels for more accurate results

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->