### PR TITLE
Display system prompt in model response #43

### DIFF
--- a/apps/webapp/src/components/prompt-responses/index.tsx
+++ b/apps/webapp/src/components/prompt-responses/index.tsx
@@ -246,6 +246,7 @@ export default function PromptResponses({
                   avgScore={
                     response.totalScoreCount > 0 ? response.avgScore : undefined
                   }
+                  systemPrompt={(response.metadata as { systemPrompt?: string })?.systemPrompt ?? null}
                   onScoreDetailsClick={
                     response.totalScoreCount > 0
                       ? () => handleScoreDetailsClick(response)

--- a/apps/webapp/src/components/response-card/index.tsx
+++ b/apps/webapp/src/components/response-card/index.tsx
@@ -5,6 +5,7 @@ import {
   LucideCheckCircle,
   LucideXCircle,
   LucideHash,
+  LucideFileText,
 } from "lucide-react";
 import { DateTime } from "luxon";
 import { capitalize } from "@/utils/capitalize";
@@ -16,6 +17,12 @@ import { Comments } from "./comments";
 import { Button } from "../ui/button";
 import { MetadataAccordion } from "../metadata-accordion";
 import { QuickFeedbackButtons } from "../quick-feedback-buttons";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "../ui/accordion";
 
 export interface ResponseCardProps {
   responseId?: string;
@@ -28,7 +35,7 @@ export interface ResponseCardProps {
   score?: number;
   avgScore?: number;
   children?: React.ReactNode;
-
+  systemPrompt?: string | null;
   onScoreDetailsClick?: () => void;
 }
 
@@ -43,6 +50,7 @@ function ResponseCard({
   children,
   responseId,
   isRevealed,
+  systemPrompt,
   onScoreDetailsClick,
 }: ResponseCardProps) {
   return (
@@ -123,6 +131,23 @@ function ResponseCard({
           <div className="text-gray-600 italic p-3 border rounded-lg bg-gray-50 border-gray-200">
             Response is not revealed yet
           </div>
+        )}
+        {systemPrompt && systemPrompt.trim() !== "" && (
+          <Accordion type="single" collapsible>
+            <AccordionItem value="system-prompt">
+              <AccordionTrigger className="pl-4 pt-4 pb-4 text-sm font-medium">
+                <div className="flex items-center gap-2">
+                  <LucideFileText size={16} />
+                  System Prompt
+                </div>
+              </AccordionTrigger>
+              <AccordionContent className="p-5 bg-card-content-container">
+                <pre className="whitespace-pre-wrap text-sm text-gray-700 font-mono">
+                  {systemPrompt}
+                </pre>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
         )}
         {findComponent(children, Comments)}
         {metadata && Object.keys(metadata).length > 0 && (


### PR DESCRIPTION
Issue #43
## Description
This feature adds the ability to display system prompts alongside model responses.

## Files Changed
- apps/webapp/src/components/prompt-responses/index.tsx
- apps/webapp/src/components/response-card/index.tsx

## Screenshots
<img width="1223" height="391" alt="image" src="https://github.com/user-attachments/assets/b2c1b1dd-6e01-4da1-ac16-aade87d3cba1" />
<img width="1224" height="457" alt="image" src="https://github.com/user-attachments/assets/1e49fea3-8144-4b2d-b685-1c8ea6116513" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System prompts now appear in a collapsible "System Prompt" section within response details, shown in a readable, preformatted block so you can review the original prompt without cluttering the main response view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->